### PR TITLE
never set SVG attributes as props

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -21,7 +21,7 @@ function getKey(node) {
   return node && node.props ? node.props.key : null
 }
 
-function setElementProp(element, name, value, oldValue) {
+function setElementProp(element, name, value, isSVG, oldValue) {
   if (name === "key") {
   } else if (name === "style") {
     for (var i in copy(oldValue, (value = value || {}))) {
@@ -30,7 +30,7 @@ function setElementProp(element, name, value, oldValue) {
   } else {
     var empty = null == value || false === value
 
-    if (name in element) {
+    if (name in element && !isSVG) {
       try {
         element[name] = null == value ? "" : value
       } catch (_) {}
@@ -63,18 +63,18 @@ function createElement(node, isSVG) {
     }
 
     for (var i in node.props) {
-      setElementProp(element, i, node.props[i])
+      setElementProp(element, i, node.props[i], isSVG)
     }
   }
   return element
 }
 
-function updateElement(element, oldProps, props) {
+function updateElement(element, oldProps, props, isSVG) {
   for (var i in copy(oldProps, props)) {
     var oldValue = "value" === i || "checked" === i ? element[i] : oldProps[i]
 
     if (props[i] !== oldValue) {
-      setElementProp(element, i, props[i], oldValue)
+      setElementProp(element, i, props[i], isSVG, oldValue)
     }
   }
 
@@ -114,7 +114,7 @@ function patchElement(parent, element, oldNode, node, isSVG, nextSibling) {
   if (oldNode == null) {
     element = parent.insertBefore(createElement(node, isSVG), element)
   } else if (node.type != null && node.type === oldNode.type) {
-    updateElement(element, oldNode.props, node.props)
+    updateElement(element, oldNode.props, node.props, isSVG)
 
     isSVG = isSVG || node.type === "svg"
 


### PR DESCRIPTION
Applies [this change](https://github.com/hyperapp/hyperapp/commit/4f147c2ec00fd2a69b2298981a81372c603211ca?diff=unified#diff-1fdf421c05c1140f6d71444ea2b27638) from Hyperapp.

Closes #80

~~Note that there's no impact on tests, as we don't have tests for SVG support.~~ yes we do.

~~There is a potential minor problem with this approach - it may be acceptable, but seems a bit wrong, we're now treating *all* SVG properties as `string` types, which isn't quite right.~~

@JorgeBucaran to clarify per your comment before the original PR was lost: this was a total brain fart - we're of course comparing the historical VDOM property values, so the string conversion that happens when we set DOM attributes of course doesn't affect that. Duh, silly me 🙄 

So I think this one is likely good to go?
