### PR TITLE
add test for file size constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "babel-preset-env": "^1.6.0",
+    "gzip-size": "^4.1.0",
     "jest": "^21.2.1",
     "prettier": "~1.7.4",
     "rollup": "^0.50.0",

--- a/test/filesize.test.js
+++ b/test/filesize.test.js
@@ -1,0 +1,12 @@
+const gzip_size = require("gzip-size")
+
+test("file size constraint", () => {
+  const LIMIT = 1024
+
+  return gzip_size.file("./dist/picodom.js").then(size => {
+    if (size > LIMIT) {
+      let overage = size - LIMIT
+      console.warn(`File size: ${ size } (${ overage} over ${ LIMIT } limit)`)
+    }
+  })
+})


### PR DESCRIPTION
Per the title, this adds a test for the 1KB file-size constraint.

It won't fail the test on overage, it'll only warn you on the console:

```
 PASS  test/filesize.test.js
  ● Console

    console.warn test/filesize.test.js:9
      File size: 1167 (143 over 1024 limit)
```

My gut feeling is there probably isn't much we can do, as everything is pretty compact already, and as said, I'd hate to the see code become more garbled (or features to get cut!) in favor of byte-size savings.

Maybe this will change if @JorgeBucaran gets around to rewriting a simpler patch function?
