### PR TITLE
API update - mount() for mounting, patch() for patching

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
 export { h } from "./h"
-export { patch } from "./patch"
+export { patch, mount } from "./patch"

--- a/src/patch.js
+++ b/src/patch.js
@@ -1,11 +1,19 @@
 var callbacks = []
 
-export function patch(parent, oldNode, newNode) {
-  var element = patchElement(parent, parent.children[0], oldNode, newNode)
+export function mount(parent, node) {
+  var element = parent.appendChild(createElement(node))
 
   for (var cb; (cb = callbacks.pop()); cb()) {}
 
   return element
+}
+
+export function patch(oldNode, newNode) {
+  newNode._ref = patchElement(oldNode._ref.parentNode, oldNode._ref, oldNode, newNode)
+
+  for (var cb; (cb = callbacks.pop()); cb()) {}
+
+  return newNode._ref
 }
 
 function copy(target, source) {
@@ -65,6 +73,8 @@ function createElement(node, isSVG) {
     for (var i in node.props) {
       setElementProp(element, i, node.props[i])
     }
+
+    node._ref = element
   }
   return element
 }


### PR DESCRIPTION
As mentioned in #89, the current `patch()` API essentially does double duty: mounting to the DOM at a single node, and updating the tree as the application updates.

This PR aims to introduce a separate `mount()` function and updates the `patch()` function's API to support patching at any level of the tree.

```javascript
/** @jsx h */
import { h, mount, patch } from 'picodom'

const App = props => <h1>{props.title}</h1

let root = <App title='Hello world!' />

mount(document.body, root)

// after state updates
patch(root, (root = <App title='New title' />))
```

As you can see, it adds a few lines, but perhaps there is a more compact way 🤔 

As far as introducing a new method to the API, I think it's a good idea. "Mounting" and "patching" are different concerns, and a single API for both would be confusing IMO.

## TODO
If you like this direction, I'm happy to make any updates necessary to get it integrated 🎉 

The tests are failing currently, I could probably use some direction there: `parentNode` is undefined. Throughout the suite `patch` would need to be updated to `mount` and the params slightly rearranged.

Thanks!

